### PR TITLE
Install missing Java dependency for Jenkins and add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 .vagrant/
 *.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vagrant Jenkins build
 
-Run a Jenkins 2.25 instance on Ubuntu 16.04 LTS using vagrant.
+Run latest Jenkins instance on Ubuntu 16.04 LTS using vagrant.
 
 ## Prerequisites
 * [VirtualBox](https://www.virtualbox.org/)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/mnt/host_machine"
   config.vm.provider :virtualbox do |vb|
       vb.name = "jenkins"
+      vb.memory = "2048"
   end
   config.vm.provision "shell" do |s|
     s.path = "provision.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,9 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.provider :virtualbox do |vb|
+          vb.name = "jenkins"
+      end
   config.vm.provision "shell" do |s|
     s.path = "provision.sh"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.provider :virtualbox do |vb|
-          vb.name = "jenkins"
-      end
+      vb.name = "jenkins"
+  end
   config.vm.provision "shell" do |s|
     s.path = "provision.sh"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.synced_folder ".", "host_machine"
+  config.vm.synced_folder ".", "/mnt/host_machine"
   config.vm.provider :virtualbox do |vb|
       vb.name = "jenkins"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.synced_folder ".", "host_machine"
   config.vm.provider :virtualbox do |vb|
       vb.name = "jenkins"
   end

--- a/provision.sh
+++ b/provision.sh
@@ -8,8 +8,8 @@ sudo apt-get -y install openjdk-8-jre-headless
 echo "Installing Jenkins"
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
-sudo apt-get update > /dev/null 2>&1
-sudo apt-get -y install jenkins > /dev/null 2>&1
+sudo apt-get update #> /dev/null 2>&1
+sudo apt-get -y install jenkins #> /dev/null 2>&1
 
 
 ########################

--- a/provision.sh
+++ b/provision.sh
@@ -19,7 +19,8 @@ sudo apt-get -y install npm
 ########################
 # Docker
 ########################
-sudo apt-get -y install docker-ce
+sudo apt-get -y install docker.io
+sudo usermod -aG docker ${USER}
 
 ########################
 # nginx

--- a/provision.sh
+++ b/provision.sh
@@ -3,16 +3,11 @@
 ########################
 # Jenkins & Java
 ########################
-echo "Installing Java"
-sudo apt-get -y install openjdk-8-jre-headless
-echo "Installing Jenkins"
+echo "Installing Jenkins and Java"
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update > /dev/null 2>&1
 sudo apt-get -y install default-jdk jenkins > /dev/null 2>&1
-sudo apt-get update > /dev/null 2>&1
-sudo apt-get -y install jenkins > /dev/null 2>&1
-
 
 ########################
 # Node & npm

--- a/provision.sh
+++ b/provision.sh
@@ -16,6 +16,7 @@ sudo apt-get -y install jenkins > /dev/null 2>&1
 # Node & npm
 ########################
 echo "Installing Node & npm"
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get -y install nodejs
 sudo apt-get -y install npm
 

--- a/provision.sh
+++ b/provision.sh
@@ -28,6 +28,7 @@ sudo apt-get -y install docker.io
 sudo systemctl enable docker
 sudo usermod -aG docker ${USER}
 sudo usermod -aG docker jenkins
+sudo usermod -aG docker ubuntu
 
 ########################
 # nginx

--- a/provision.sh
+++ b/provision.sh
@@ -24,7 +24,10 @@ sudo apt-get -y install npm
 # Docker
 ########################
 echo "Installing Docker"
-sudo apt-get -y install docker.io
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y install docker-ce
 sudo systemctl enable docker
 sudo usermod -aG docker ${USER}
 sudo usermod -aG docker jenkins

--- a/provision.sh
+++ b/provision.sh
@@ -40,9 +40,9 @@ sudo service nginx start
 ########################
 echo "Configuring nginx"
 cd /etc/nginx/sites-available
-#sudo rm default ../sites-enabled/default
-#sudo cp /vagrant/VirtualHost/jenkins /etc/nginx/sites-available/
-#sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
+sudo rm default ../sites-enabled/default
+sudo cp /vagrant/VirtualHost/jenkins /etc/nginx/sites-available/
+sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
 sudo service nginx restart
 sudo service jenkins restart
 echo "Success"

--- a/provision.sh
+++ b/provision.sh
@@ -9,6 +9,18 @@ sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources
 sudo apt-get update > /dev/null 2>&1
 sudo apt-get -y install jenkins > /dev/null 2>&1
 
+
+########################
+# Node & npm
+########################
+sudo apt-get -y install nodejs
+sudo apt-get -y install npm
+
+########################
+# Docker
+########################
+sudo apt-get -y install docker-ce
+
 ########################
 # nginx
 ########################

--- a/provision.sh
+++ b/provision.sh
@@ -4,7 +4,7 @@
 # Jenkins & Java
 ########################
 echo "Installing Java"
-sudo apt-get -y install openjdk-7-jre-headless
+sudo apt-get -y install openjdk-8-jre-headless
 echo "Installing Jenkins"
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
@@ -24,7 +24,9 @@ sudo apt-get -y install npm
 ########################
 echo "Installing Docker"
 sudo apt-get -y install docker.io
+sudo systemctl enable docker
 sudo usermod -aG docker ${USER}
+sudo usermod -aG docker jenkins
 
 ########################
 # nginx

--- a/provision.sh
+++ b/provision.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 ########################
-# Jenkins
+# Jenkins & Java
 ########################
+echo "Installing Java"
+sudo apt-get -y install openjdk-7-jre-headless
 echo "Installing Jenkins"
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
@@ -13,12 +15,14 @@ sudo apt-get -y install jenkins > /dev/null 2>&1
 ########################
 # Node & npm
 ########################
+echo "Installing Node & npm"
 sudo apt-get -y install nodejs
 sudo apt-get -y install npm
 
 ########################
 # Docker
 ########################
+echo "Installing Docker"
 sudo apt-get -y install docker.io
 sudo usermod -aG docker ${USER}
 

--- a/provision.sh
+++ b/provision.sh
@@ -34,9 +34,9 @@ sudo service nginx start
 ########################
 echo "Configuring nginx"
 cd /etc/nginx/sites-available
-sudo rm default ../sites-enabled/default
-sudo cp /vagrant/VirtualHost/jenkins /etc/nginx/sites-available/
-sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
+#sudo rm default ../sites-enabled/default
+#sudo cp /vagrant/VirtualHost/jenkins /etc/nginx/sites-available/
+#sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
 sudo service nginx restart
 sudo service jenkins restart
 echo "Success"


### PR DESCRIPTION
possibility to run docker-compose and other docker commands from Jenkins
installed Java 8 that is required for Jenkins to actually work