### PR TITLE
Install default-jdk with jenkins

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -7,7 +7,7 @@ echo "Installing Jenkins"
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update > /dev/null 2>&1
-sudo apt-get -y install jenkins > /dev/null 2>&1
+sudo apt-get -y install default-jdk jenkins > /dev/null 2>&1
 
 ########################
 # nginx


### PR DESCRIPTION
After bringing up the instance the jenkins service fails because there's no associated jdk.

This adds (currently) openjdk 1.8.0 to the install.