### PR TITLE
Use configurable host dir

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+VAGRANT_HOST_DIR=/mnt/host_machine
+
 ########################
 # Jenkins & Java
 ########################
@@ -8,9 +10,10 @@ wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key 
 sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
 sudo apt-get update > /dev/null 2>&1
 sudo apt-get -y install default-jdk jenkins > /dev/null 2>&1
-sudo cp /mnt/host_machine/JenkinsConfig/config.xml /var/lib/jenkins/
+echo "Installing Jenkins default user and config"
+sudo cp $VAGRANT_HOST_DIR/JenkinsConfig/config.xml /var/lib/jenkins/
 sudo mkdir -p /var/lib/jenkins/users/admin
-sudo cp /mnt/host_machine/JenkinsConfig/users/admin/config.xml /var/lib/jenkins/users/admin/
+sudo cp $VAGRANT_HOST_DIR/JenkinsConfig/users/admin/config.xml /var/lib/jenkins/users/admin/
 sudo chown -R jenkins:jenkins /var/lib/jenkins/users/
 
 ########################
@@ -47,7 +50,7 @@ sudo service nginx start
 echo "Configuring nginx"
 cd /etc/nginx/sites-available
 sudo rm default ../sites-enabled/default
-sudo cp /mnt/host_machine/VirtualHost/jenkins /etc/nginx/sites-available/
+sudo cp $VAGRANT_HOST_DIR/VirtualHost/jenkins /etc/nginx/sites-available/
 sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
 sudo service nginx restart
 sudo service jenkins restart


### PR DESCRIPTION
Move the host directory to a single variable definition at the top of the provision script, will help if it ever needs to be changed and for adding the directory for other items in the script.

should be merged after https://github.com/edinc/vagrant-jenkins/pull/10