### PR TITLE
Add Bats tests for Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,13 @@ language: bash
 
 notifications:
     slack: tehnografija:yGLRFooashh7wutsGmMQFxou
+
+jobs:
+  include:
+    - stage: install Bats
+      script:
+        - sudo apt-get update
+        - sudo apt-get install -y bats
+    - stage: run Bats tests
+      script:
+        - bats tests/

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ username: admin
 password: admin
 ```
 usual caveat about changing the password once setup.
+
+## Bats Tests
+
+This repository includes tests written using [Bats](https://github.com/sstephenson/bats). These tests check if Jenkins is installed, if the Jenkins service is running, and if Jenkins is accessible on port 8080.
+
+To run the tests, use the following command:
+
+```
+bats tests/
+```

--- a/provision.sh
+++ b/provision.sh
@@ -56,3 +56,9 @@ sudo ln -s /etc/nginx/sites-available/jenkins /etc/nginx/sites-enabled/
 sudo service nginx restart
 sudo service jenkins restart
 echo "Success"
+
+########################
+# Bats
+########################
+echo "Installing Bats"
+sudo apt-get -y install bats

--- a/tests/test_jenkins.bats
+++ b/tests/test_jenkins.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+@test "Jenkins is installed" {
+  run dpkg -l jenkins
+  [ "$status" -eq 0 ]
+}
+
+@test "Jenkins service is running" {
+  run systemctl is-active jenkins
+  [ "$status" -eq 0 ]
+  [ "$output" = "active" ]
+}
+
+@test "Jenkins is accessible on port 8080" {
+  run curl -s -o /dev/null -w "%{http_code}" http://localhost:8080
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 200 ]
+}


### PR DESCRIPTION
Fixes #5

Add Bats tests for Jenkins and update necessary files to support Bats testing.

* **tests/test_jenkins.bats**: Add tests to check if Jenkins is installed, if the Jenkins service is running, and if Jenkins is accessible on port 8080.
* **.travis.yml**: Add stages to install Bats and run Bats tests.
* **provision.sh**: Add command to install Bats.
* **README.md**: Add section to mention Bats and the tests written using Bats.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/edinc/vagrant-jenkins/pull/16?shareId=c4190484-48a0-403d-a0fc-74d54c16e52d).